### PR TITLE
feat: workflow for build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,73 @@
+name: Build
+
+on:
+  push:
+    branches: [main, build-workflow]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.display }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display: Linux
+            runner: ubuntu-latest
+            target: linux
+          - display: macOS
+            runner: macos-latest
+            target: mac
+          - display: Windows
+            runner: windows-latest
+            target: win
+
+    env:
+      CI: true
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+      SNAPCRAFT_BUILD_ENVIRONMENT: host
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install Linux tooling
+        if: matrix.target == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-tools rpm
+          sudo snap install snapcraft --classic
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build renderer, preload, and main
+        run: pnpm run build
+
+      - name: Package for ${{ matrix.display }}
+        run: pnpm exec electron-builder --${{ matrix.target }} --config electron-builder.yml
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dbdesk-${{ matrix.target }}
+          path: |
+            dist/**
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
     tags:
       - 'v*'
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
-name: Build
+name: Build and Release
 
 on:
   push:
-    branches: [main, build-workflow]
+    branches: [main]
+    tags:
+      - 'v*'
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -62,12 +65,38 @@ jobs:
         run: pnpm run build
 
       - name: Package for ${{ matrix.display }}
-        run: pnpm exec electron-builder --${{ matrix.target }} --config electron-builder.yml
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        run: pnpm exec electron-builder --${{ matrix.target }} --config electron-builder.yml --publish never
 
-      - name: Upload artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         with:
           name: dbdesk-${{ matrix.target }}
           path: |
-            dist/**
+            dist/**/*.{AppImage,deb,snap,rpm,zip,dmg,exe,msi,blockmap,yml}
           if-no-files-found: error
+
+  release:
+    name: Publish Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dbdesk-*
+          merge-multiple: true
+          path: artifacts
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: artifacts/**


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and releasing the project across multiple platforms. The workflow automates building, packaging, artifact uploading, and publishing releases for Linux, macOS, and Windows.

**CI/CD Automation:**

* Added a `.github/workflows/release.yml` workflow that triggers on pushes to `main`, tags starting with `v`, pull requests to `main`, and manual dispatches.
* Configured matrix builds for Linux, macOS, and Windows, ensuring cross-platform packaging and artifact generation.
* Automated installation of dependencies, build steps, and packaging using `pnpm` and `electron-builder`.

**Release Management:**

* Artifacts for each platform are uploaded as build outputs, and on tagged releases, these artifacts are published as GitHub releases using `softprops/action-gh-release`.