### PR TITLE
feat: adding query saving locally

### DIFF
--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -51,6 +51,8 @@ export type {
 // Workspace types
 export type {
   ConnectionWorkspace,
+  SavedQuery,
+  SavedQueriesStorage,
   SerializedQueryTab,
   SerializedTab,
   WorkspaceStorage

--- a/src/common/types/workspace.ts
+++ b/src/common/types/workspace.ts
@@ -18,6 +18,14 @@ export interface SerializedQueryTab {
   editorContent: string
 }
 
+export interface SavedQuery {
+  id: string
+  name: string
+  content: string
+  createdAt: Date
+  updatedAt: Date
+}
+
 export interface ConnectionWorkspace {
   connectionId: string
   lastUpdated: Date
@@ -30,4 +38,8 @@ export interface ConnectionWorkspace {
 
 export interface WorkspaceStorage {
   [connectionId: string]: ConnectionWorkspace
+}
+
+export interface SavedQueriesStorage {
+  [connectionId: string]: SavedQuery[]
 }

--- a/src/main/saved-queries-storage.ts
+++ b/src/main/saved-queries-storage.ts
@@ -1,0 +1,152 @@
+import type { SavedQuery, SavedQueriesStorage } from '@common/types'
+import { app } from 'electron'
+import { promises as fs } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+const QUERIES_FILENAME = 'saved-queries.json'
+
+type StoredQuery = Omit<SavedQuery, 'createdAt' | 'updatedAt'> & {
+  createdAt: string
+  updatedAt: string
+}
+
+type StoredQueriesStorage = {
+  [connectionId: string]: StoredQuery[]
+}
+
+const getSavedQueriesStoragePath = (): string =>
+  join(app.getPath('userData'), QUERIES_FILENAME)
+
+const serializeQuery = (query: SavedQuery): StoredQuery => ({
+  ...query,
+  createdAt: query.createdAt.toISOString(),
+  updatedAt: query.updatedAt.toISOString()
+})
+
+const deserializeQuery = (stored: StoredQuery): SavedQuery => ({
+  ...stored,
+  createdAt: new Date(stored.createdAt),
+  updatedAt: new Date(stored.updatedAt)
+})
+
+const readQueriesFromDisk = async (): Promise<StoredQueriesStorage> => {
+  const filePath = getSavedQueriesStoragePath()
+
+  try {
+    const content = await fs.readFile(filePath, 'utf8')
+    if (content.trim() === '') {
+      return {}
+    }
+
+    return JSON.parse(content) as StoredQueriesStorage
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {}
+    }
+
+    if (error instanceof SyntaxError) {
+      console.warn(`Saved queries storage file is corrupted, resetting: ${error.message}`)
+      return {}
+    }
+
+    throw error
+  }
+}
+
+const writeQueriesToDisk = async (queries: StoredQueriesStorage): Promise<void> => {
+  const filePath = getSavedQueriesStoragePath()
+  await fs.mkdir(dirname(filePath), { recursive: true }).catch(() => {})
+  await fs.writeFile(filePath, JSON.stringify(queries, null, 2), 'utf8')
+}
+
+export const saveQuery = async (
+  connectionId: string,
+  name: string,
+  content: string
+): Promise<SavedQuery> => {
+  const queries = await readQueriesFromDisk()
+  const now = new Date()
+
+  const query: SavedQuery = {
+    id: randomUUID(),
+    name,
+    content,
+    createdAt: now,
+    updatedAt: now
+  }
+
+  if (!queries[connectionId]) {
+    queries[connectionId] = []
+  }
+
+  queries[connectionId]!.push(serializeQuery(query))
+  await writeQueriesToDisk(queries)
+
+  return query
+}
+
+export const updateQuery = async (
+  connectionId: string,
+  queryId: string,
+  name: string,
+  content: string
+): Promise<SavedQuery | undefined> => {
+  const queries = await readQueriesFromDisk()
+  const connectionQueries = queries[connectionId]
+
+  if (!connectionQueries) {
+    return undefined
+  }
+
+  const index = connectionQueries.findIndex((q) => q.id === queryId)
+  if (index === -1) {
+    return undefined
+  }
+
+  const now = new Date()
+  const updated: StoredQuery = {
+    ...connectionQueries[index]!,
+    name,
+    content,
+    updatedAt: now.toISOString()
+  }
+
+  connectionQueries[index] = updated
+  await writeQueriesToDisk(queries)
+
+  return deserializeQuery(updated)
+}
+
+export const deleteQuery = async (connectionId: string, queryId: string): Promise<void> => {
+  const queries = await readQueriesFromDisk()
+
+  if (queries[connectionId]) {
+    queries[connectionId] = queries[connectionId]!.filter((q) => q.id !== queryId)
+    await writeQueriesToDisk(queries)
+  }
+}
+
+export const loadQueries = async (connectionId: string): Promise<SavedQuery[]> => {
+  const queries = await readQueriesFromDisk()
+  const connectionQueries = queries[connectionId] || []
+
+  return connectionQueries.map((q) => deserializeQuery(q))
+}
+
+export const loadAllQueries = async (): Promise<SavedQueriesStorage> => {
+  const storedQueries = await readQueriesFromDisk()
+  const queries: SavedQueriesStorage = {}
+
+  for (const [connectionId, storedQueryList] of Object.entries(storedQueries)) {
+    queries[connectionId] = storedQueryList.map((q) => deserializeQuery(q))
+  }
+
+  return queries
+}
+
+export const deleteAllQueriesForConnection = async (connectionId: string): Promise<void> => {
+  const queries = await readQueriesFromDisk()
+  delete queries[connectionId]
+  await writeQueriesToDisk(queries)
+}

--- a/src/preload/dbdesk-api.ts
+++ b/src/preload/dbdesk-api.ts
@@ -5,6 +5,7 @@ import type {
   DeleteTableRowsResult,
   QueryResult,
   QueryResultRow,
+  SavedQuery,
   SchemaWithTables,
   TableDataOptions,
   TableDataResult,
@@ -345,6 +346,85 @@ export const dbdeskAPI = {
     }
 
     return ipcRenderer.invoke('workspace:delete', { connectionId: connectionId.trim() })
+  },
+
+  /**
+   * Load all saved queries for a connection
+   */
+  async loadQueries(connectionId: string): Promise<SavedQuery[]> {
+    if (!connectionId || typeof connectionId !== 'string' || connectionId.trim() === '') {
+      throw new Error('Connection ID is required')
+    }
+
+    return ipcRenderer.invoke('queries:load', { connectionId: connectionId.trim() })
+  },
+
+  /**
+   * Save a new query for a connection
+   */
+  async saveQuery(connectionId: string, name: string, content: string): Promise<SavedQuery> {
+    if (!connectionId || typeof connectionId !== 'string' || connectionId.trim() === '') {
+      throw new Error('Connection ID is required')
+    }
+    if (!name || typeof name !== 'string' || name.trim() === '') {
+      throw new Error('Query name is required')
+    }
+    if (!content || typeof content !== 'string' || content.trim() === '') {
+      throw new Error('Query content is required')
+    }
+
+    return ipcRenderer.invoke('queries:save', {
+      connectionId: connectionId.trim(),
+      name: name.trim(),
+      content: content.trim()
+    })
+  },
+
+  /**
+   * Delete a saved query
+   */
+  async deleteQuery(connectionId: string, queryId: string): Promise<void> {
+    if (!connectionId || typeof connectionId !== 'string' || connectionId.trim() === '') {
+      throw new Error('Connection ID is required')
+    }
+    if (!queryId || typeof queryId !== 'string' || queryId.trim() === '') {
+      throw new Error('Query ID is required')
+    }
+
+    return ipcRenderer.invoke('queries:delete', {
+      connectionId: connectionId.trim(),
+      queryId: queryId.trim()
+    })
+  },
+
+  /**
+   * Update an existing saved query
+   */
+  async updateQuery(
+    connectionId: string,
+    queryId: string,
+    name: string,
+    content: string
+  ): Promise<SavedQuery | undefined> {
+    if (!connectionId || typeof connectionId !== 'string' || connectionId.trim() === '') {
+      throw new Error('Connection ID is required')
+    }
+    if (!queryId || typeof queryId !== 'string' || queryId.trim() === '') {
+      throw new Error('Query ID is required')
+    }
+    if (!name || typeof name !== 'string' || name.trim() === '') {
+      throw new Error('Query name is required')
+    }
+    if (!content || typeof content !== 'string' || content.trim() === '') {
+      throw new Error('Query content is required')
+    }
+
+    return ipcRenderer.invoke('queries:update', {
+      connectionId: connectionId.trim(),
+      queryId: queryId.trim(),
+      name: name.trim(),
+      content: content.trim()
+    })
   }
 }
 

--- a/src/renderer/src/api/client.ts
+++ b/src/renderer/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   DeleteTableRowsResult,
   QueryResult,
   QueryResultRow,
+  SavedQuery,
   SchemaWithTables,
   TableDataOptions,
   TableDataResult,
@@ -123,6 +124,27 @@ export const dbdeskClient = {
 
   async deleteWorkspace(connectionId: string): Promise<void> {
     return getDbdesk().deleteWorkspace(connectionId)
+  },
+
+  async loadQueries(connectionId: string): Promise<SavedQuery[]> {
+    return getDbdesk().loadQueries(connectionId)
+  },
+
+  async saveQuery(connectionId: string, name: string, content: string): Promise<SavedQuery> {
+    return getDbdesk().saveQuery(connectionId, name, content)
+  },
+
+  async deleteQuery(connectionId: string, queryId: string): Promise<void> {
+    return getDbdesk().deleteQuery(connectionId, queryId)
+  },
+
+  async updateQuery(
+    connectionId: string,
+    queryId: string,
+    name: string,
+    content: string
+  ): Promise<SavedQuery | undefined> {
+    return getDbdesk().updateQuery(connectionId, queryId, name, content)
   }
 }
 
@@ -133,6 +155,7 @@ export type {
   DeleteTableRowsResult,
   QueryResult,
   QueryResultRow,
+  SavedQuery,
   SchemaWithTables,
   TableDataOptions,
   TableDataResult,

--- a/src/renderer/src/components/dialogs/save-query-dialog.tsx
+++ b/src/renderer/src/components/dialogs/save-query-dialog.tsx
@@ -1,0 +1,87 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@renderer/components/ui/alert-dialog'
+import { Input } from '@renderer/components/ui/input'
+import { useState } from 'react'
+
+type SaveQueryDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSave: (name: string) => Promise<void>
+  isLoading?: boolean
+  title?: string
+  description?: string
+  placeholder?: string
+  submitText?: string
+  initialValue?: string
+}
+
+export function SaveQueryDialog({
+  open,
+  onOpenChange,
+  onSave,
+  isLoading,
+  title = 'Save Query',
+  description = 'Give your query a memorable name so you can find it easily later',
+  placeholder = 'e.g., Find users by email',
+  submitText = 'Save',
+  initialValue = ''
+}: SaveQueryDialogProps) {
+  const [name, setName] = useState(initialValue)
+
+  const handleSave = async () => {
+    const trimmedName = name.trim()
+    if (!trimmedName) return
+
+    try {
+      await onSave(trimmedName)
+      setName(initialValue)
+      onOpenChange(false)
+    } catch (error) {
+      console.error('Failed to save query:', error)
+    }
+  }
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setName(initialValue)
+    }
+    onOpenChange(isOpen)
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          placeholder={placeholder}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleSave()
+            }
+          }}
+          disabled={isLoading}
+          autoFocus
+        />
+        <AlertDialogFooter className="flex gap-2">
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleSave} disabled={!name.trim() || isLoading}>
+            {isLoading ? `${submitText}ing...` : submitText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/components/sql/query-view/query-sidebar.tsx
+++ b/src/renderer/src/components/sql/query-view/query-sidebar.tsx
@@ -1,49 +1,188 @@
 import type { SQLConnectionProfile } from '@common/types'
+import { SaveQueryDialog } from '@renderer/components/dialogs/save-query-dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@renderer/components/ui/dropdown-menu'
 import {
   Sidebar,
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
-  SidebarHeader
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem
 } from '@renderer/components/ui/sidebar'
+import { useQueryTabStore } from '@renderer/store/query-tab-store'
+import { useSavedQueriesStore } from '@renderer/store/saved-queries-store'
 import { useSqlWorkspaceStore } from '@renderer/store/sql-workspace-store'
+import { ArrowLeft, FileText, MoreVertical, Pencil, Trash2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
 import { Button } from '../../ui/button'
-import { ArrowLeft } from 'lucide-react'
 
 type QuerySidebarProps = {
   profile: SQLConnectionProfile
 }
 
+type RenameMode = {
+  open: boolean
+  queryId: string | null
+}
+
 export function QuerySidebar({ profile }: QuerySidebarProps) {
   const { setView } = useSqlWorkspaceStore()
+  const { queries, loadQueries, deleteQuery, updateQuery } = useSavedQueriesStore()
+  const { addTab, setActiveTab, findTabBySavedQueryId, updateTab } = useQueryTabStore()
+  const [renameMode, setRenameMode] = useState<RenameMode>({ open: false, queryId: null })
+
+  useEffect(() => {
+    loadQueries(profile.id).catch((error) => {
+      console.error('Failed to load queries:', error)
+    })
+  }, [profile.id, loadQueries])
+
+  const handleLoadQuery = (query: (typeof queries)[0]) => {
+    // Check if a tab with this saved query already exists
+    const existingTab = findTabBySavedQueryId(query.id)
+    if (existingTab) {
+      setActiveTab(existingTab.id)
+      return
+    }
+
+    // Create new tab with the saved query ID
+    const newTabId = addTab(query.id)
+    // The tab will be added and activated, then we can update it with the saved query
+    setTimeout(() => {
+      updateTab(newTabId, {
+        name: query.name,
+        editorContent: query.content
+      })
+    }, 0)
+  }
+
+  const handleDeleteQuery = async (queryId: string) => {
+    try {
+      await deleteQuery(profile.id, queryId)
+      toast.success('Query deleted')
+    } catch (error) {
+      toast.error('Failed to delete query')
+    }
+  }
+
+  const handleRenameQuery = async (newName: string) => {
+    if (!renameMode.queryId) return
+
+    const query = queries.find((q) => q.id === renameMode.queryId)
+    if (!query) return
+
+    try {
+      await updateQuery(profile.id, renameMode.queryId, newName, query.content)
+      toast.success('Query renamed')
+
+      // Update any open tabs with this query
+      const tab = findTabBySavedQueryId(renameMode.queryId)
+      if (tab) {
+        updateTab(tab.id, { name: newName })
+      }
+    } catch (error) {
+      toast.error('Failed to rename query')
+    }
+  }
+
+  const selectedQuery = renameMode.queryId ? queries.find((q) => q.id === renameMode.queryId) : null
 
   return (
-    <Sidebar className="border-r w-full h-full" collapsible="none">
-      <SidebarHeader>
-        <SidebarGroupLabel>{profile.name}</SidebarGroupLabel>
-        <SidebarGroup className="flex flex-col gap-2">
-          <Button
-            variant="outline"
-            className="w-full justify-start gap-2 cursor-pointer"
-            onClick={() => setView('table')}
-          >
-            <ArrowLeft className="size-4" />
-            Back to Tables
-          </Button>
-        </SidebarGroup>
-      </SidebarHeader>
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel>Saved Queries</SidebarGroupLabel>
-          <SidebarGroupContent>
-            {/* Saved queries will be displayed here later */}
-            <div className="p-4 text-sm text-muted-foreground text-center">
-              No saved queries yet
-            </div>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-    </Sidebar>
+    <>
+      <Sidebar className="border-r w-full h-full" collapsible="none">
+        <SidebarHeader>
+          <SidebarGroupLabel>{profile.name}</SidebarGroupLabel>
+          <SidebarGroup className="flex flex-col gap-2">
+            <Button
+              variant="outline"
+              className="w-full justify-start gap-2 cursor-pointer"
+              onClick={() => setView('table')}
+            >
+              <ArrowLeft className="size-4" />
+              Back to Tables
+            </Button>
+          </SidebarGroup>
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Saved Queries</SidebarGroupLabel>
+            <SidebarGroupContent>
+              {queries.length === 0 ? (
+                <div className="p-4 text-sm text-muted-foreground text-center">
+                  No saved queries yet
+                  <div className="text-xs mt-2">Press Ctrl+S to save a query</div>
+                </div>
+              ) : (
+                <SidebarMenu>
+                  {queries.map((query) => (
+                    <SidebarMenuItem key={query.id}>
+                      <div className="flex items-center justify-between w-full px-2 rounded-md hover:bg-accent group">
+                        <SidebarMenuButton
+                          onClick={() => handleLoadQuery(query)}
+                          className="flex-1 cursor-pointer gap-2"
+                          asChild
+                        >
+                          <button className="text-left">
+                            <FileText className="size-4 flex-shrink-0" />
+                            <span className="truncate">{query.name}</span>
+                          </button>
+                        </SidebarMenuButton>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button className="opacity-0 group-hover:opacity-100 transition-opacity p-1 hover:bg-accent rounded cursor-pointer">
+                              <MoreVertical className="size-4" />
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setRenameMode({ open: true, queryId: query.id })
+                              }}
+                              className="cursor-pointer"
+                            >
+                              <Pencil className="size-4 mr-2" />
+                              Rename
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => handleDeleteQuery(query.id)}
+                              className="cursor-pointer text-destructive"
+                            >
+                              <Trash2 className="size-4 mr-2" />
+                              Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              )}
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+      </Sidebar>
+
+      {selectedQuery && (
+        <SaveQueryDialog
+          open={renameMode.open}
+          onOpenChange={(open) => setRenameMode({ ...renameMode, open })}
+          title="Rename Query"
+          description="Enter a new name for your query"
+          placeholder={selectedQuery.name}
+          submitText="Rename"
+          initialValue={selectedQuery.name}
+          onSave={handleRenameQuery}
+        />
+      )}
+    </>
   )
 }

--- a/src/renderer/src/store/query-tab-store.ts
+++ b/src/renderer/src/store/query-tab-store.ts
@@ -6,6 +6,7 @@ export interface QueryTab {
   name: string // tab name (e.g., "Untitled Query")
   editorContent: string // SQL query content in the editor
   queryResults?: QueryResult // query results
+  savedQueryId?: string // ID of the saved query (if opened from saved queries)
 }
 
 interface QueryTabStore {
@@ -13,11 +14,12 @@ interface QueryTabStore {
   activeTabId: string | null
 
   // Actions
-  addTab: () => string // returns tab id
+  addTab: (savedQueryId?: string) => string // returns tab id
   removeTab: (tabId: string) => void
   setActiveTab: (tabId: string) => void
   updateTab: (tabId: string, updates: Partial<QueryTab>) => void
   getActiveTab: () => QueryTab | undefined
+  findTabBySavedQueryId: (savedQueryId: string) => QueryTab | undefined
   reset: () => void
 
   // Persistence methods
@@ -27,13 +29,14 @@ interface QueryTabStore {
 
 let tabCounter = 1
 
-const createDefaultTab = (): QueryTab => {
+const createDefaultTab = (savedQueryId?: string): QueryTab => {
   const tabNumber = tabCounter++
   return {
     id: `query-${tabNumber}`,
     name: 'Untitled Query',
     editorContent: '',
-    queryResults: undefined
+    queryResults: undefined,
+    savedQueryId
   }
 }
 
@@ -41,8 +44,8 @@ export const useQueryTabStore = create<QueryTabStore>((set, get) => ({
   tabs: [],
   activeTabId: null,
 
-  addTab: () => {
-    const newTab = createDefaultTab()
+  addTab: (savedQueryId?: string) => {
+    const newTab = createDefaultTab(savedQueryId)
     set((state) => ({
       tabs: [...state.tabs, newTab],
       activeTabId: newTab.id
@@ -91,6 +94,11 @@ export const useQueryTabStore = create<QueryTabStore>((set, get) => ({
   getActiveTab: () => {
     const { tabs, activeTabId } = get()
     return tabs.find((t) => t.id === activeTabId)
+  },
+
+  findTabBySavedQueryId: (savedQueryId: string) => {
+    const { tabs } = get()
+    return tabs.find((t) => t.savedQueryId === savedQueryId)
   },
 
   reset: () => {

--- a/src/renderer/src/store/saved-queries-store.ts
+++ b/src/renderer/src/store/saved-queries-store.ts
@@ -1,0 +1,97 @@
+import type { SavedQuery } from '@common/types'
+import { dbdeskClient } from '@renderer/api/client'
+import { create } from 'zustand'
+
+interface SavedQueriesStore {
+  queries: SavedQuery[]
+  isLoading: boolean
+  error: string | null
+
+  // Actions
+  loadQueries: (connectionId: string) => Promise<void>
+  saveQuery: (connectionId: string, name: string, content: string) => Promise<SavedQuery>
+  deleteQuery: (connectionId: string, queryId: string) => Promise<void>
+  updateQuery: (
+    connectionId: string,
+    queryId: string,
+    name: string,
+    content: string
+  ) => Promise<SavedQuery | undefined>
+  reset: () => void
+}
+
+export const useSavedQueriesStore = create<SavedQueriesStore>((set) => ({
+  queries: [],
+  isLoading: false,
+  error: null,
+
+  loadQueries: async (connectionId: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      const queries = await dbdeskClient.loadQueries(connectionId)
+      set({ queries, isLoading: false })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load queries'
+      set({ error: message, isLoading: false })
+      throw error
+    }
+  },
+
+  saveQuery: async (connectionId: string, name: string, content: string) => {
+    try {
+      const query = await dbdeskClient.saveQuery(connectionId, name, content)
+      set((state) => ({
+        queries: [...state.queries, query]
+      }))
+      return query
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to save query'
+      set({ error: message })
+      throw error
+    }
+  },
+
+  deleteQuery: async (connectionId: string, queryId: string) => {
+    try {
+      await dbdeskClient.deleteQuery(connectionId, queryId)
+      set((state) => ({
+        queries: state.queries.filter((q) => q.id !== queryId)
+      }))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete query'
+      set({ error: message })
+      throw error
+    }
+  },
+
+  updateQuery: async (
+    connectionId: string,
+    queryId: string,
+    name: string,
+    content: string
+  ) => {
+    try {
+      const query = await dbdeskClient.updateQuery(connectionId, queryId, name, content)
+
+      if (query) {
+        set((state) => ({
+          queries: state.queries.map((q) => (q.id === queryId ? query : q))
+        }))
+      }
+
+      return query
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update query'
+      set({ error: message })
+      throw error
+    }
+  },
+
+  reset: () => {
+    set({
+      queries: [],
+      isLoading: false,
+      error: null
+    })
+  }
+}))


### PR DESCRIPTION
This pull request adds support for saving, loading, updating, and deleting user queries per database connection. It introduces a new saved queries storage system, IPC handlers, and frontend integration, allowing users to persist and manage named SQL queries within the application. The changes affect both backend and frontend code, including new types, storage logic, API methods, and UI components.

### Saved Queries Storage System

* Added new types `SavedQuery` and `SavedQueriesStorage` to represent saved queries and their storage per connection in `src/common/types/workspace.ts` and exported them in relevant type index files. [[1]](diffhunk://#diff-6a375142ac9e43f5dbaf803ca35f97bcbe2e8e9df341bba9b0ba5f505dc55854R21-R28) [[2]](diffhunk://#diff-6a375142ac9e43f5dbaf803ca35f97bcbe2e8e9df341bba9b0ba5f505dc55854R42-R45) [[3]](diffhunk://#diff-645d7b181c1c1ad8dd540b2b2b6bd2e5e28cb5efc3d6dfe11a40015dbf60d8b7R54-R55)
* Implemented `src/main/saved-queries-storage.ts` to handle reading, writing, serialization, and management of saved queries on disk, including functions for saving, updating, deleting, loading, and bulk deletion for a connection.

### IPC and API Integration

* Registered new IPC handlers in `src/main/ipc-handlers.ts` for saving, loading, updating, and deleting queries, with input validation and error handling. Also ensures saved queries are cleaned up when a connection is deleted. [[1]](diffhunk://#diff-0cb094d2db3887cb4e4b345b1a910d95263539aba062739c8bce394314423a93R33-R39) [[2]](diffhunk://#diff-0cb094d2db3887cb4e4b345b1a910d95263539aba062739c8bce394314423a93R189) [[3]](diffhunk://#diff-0cb094d2db3887cb4e4b345b1a910d95263539aba062739c8bce394314423a93R311-R376)
* Exposed saved queries API methods in `src/preload/dbdesk-api.ts` and `src/renderer/src/api/client.ts` for use in the renderer process, including type exports and method implementations. [[1]](diffhunk://#diff-87589cb641933cfc9b2ffeabe1ade882d5cb4573ad38c5dba7bb95476aba7b25R349-R427) [[2]](diffhunk://#diff-c3ebfa50e071fd4826d558a1fac2ef5b37318cf5647f5f372ed6f534400d0e79R127-R147) [[3]](diffhunk://#diff-c3ebfa50e071fd4826d558a1fac2ef5b37318cf5647f5f372ed6f534400d0e79R158)

### UI and User Experience

* Added a new `SaveQueryDialog` component for naming and saving queries, with validation and feedback.
* Integrated the save query dialog into the SQL query view (`src/renderer/src/components/sql/query-view/index.tsx`), including a keyboard shortcut (Ctrl+S) to trigger saving, and connected it to the saved queries store for persistence and UI feedback. [[1]](diffhunk://#diff-9278ba8f9533e250605be6413bd7e77460ef6b9cbce51eec08f66e78e8207bafR41-R57) [[2]](diffhunk://#diff-9278ba8f9533e250605be6413bd7e77460ef6b9cbce51eec08f66e78e8207bafR87-R103) [[3]](diffhunk://#diff-9278ba8f9533e250605be6413bd7e77460ef6b9cbce51eec08f66e78e8207bafR150-R156)

### State Management

* Connected the query view and dialog to a new `useSavedQueriesStore` for managing saved queries in the frontend state. [[1]](diffhunk://#diff-9278ba8f9533e250605be6413bd7e77460ef6b9cbce51eec08f66e78e8207bafR13) [[2]](diffhunk://#diff-9278ba8f9533e250605be6413bd7e77460ef6b9cbce51eec08f66e78e8207bafR28-R30)

---

These changes collectively enable users to save, retrieve, update, and delete named SQL queries for each database connection, improving workflow and productivity.