### PR TITLE
fix: remove electronLanguages from builder config

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,7 +19,6 @@ compression: maximum
 asar: true
 asarUnpack:
   - resources/**
-electronLanguages: 'en'
 # Remove unnecessary Electron files
 removePackageKeywords: true
 win:


### PR DESCRIPTION
The same caused a Locale error, resulting in devtools not opening in production builds and dialog blanking on windows. Just removing the config solves the problem.