### PR TITLE
Add SSL mode support to MySQL adapter

### DIFF
--- a/src/common/types/sql.ts
+++ b/src/common/types/sql.ts
@@ -13,6 +13,11 @@ export type PostgreSQLSslMode =
   | 'verify-full'
 
 /**
+ * MySQL SSL mode
+ */
+export type MySQLSslMode = 'disable' | 'prefer' | 'require' | 'verify-ca' | 'verify-identity'
+
+/**
  * SQL database connection options (PostgreSQL, MySQL)
  */
 export interface SQLConnectionOptions {
@@ -22,6 +27,7 @@ export interface SQLConnectionOptions {
   user: string
   password: string
   sslMode?: PostgreSQLSslMode
+  mysqlSslMode?: MySQLSslMode
 }
 
 /**

--- a/src/main/adapters/mysql.ts
+++ b/src/main/adapters/mysql.ts
@@ -15,7 +15,8 @@ import type {
   UpdateTableCellOptions,
   UpdateTableCellResult
 } from '@common/types'
-import type { FieldPacket, Pool, ResultSetHeader, RowDataPacket } from 'mysql2/promise'
+import type { MySQLSslMode } from '@common/types/sql'
+import type { FieldPacket, Pool, ResultSetHeader, RowDataPacket, SslOptions } from 'mysql2/promise'
 import * as mysql from 'mysql2/promise'
 import { performance } from 'node:perf_hooks'
 
@@ -38,6 +39,26 @@ import { isSelectableQuery, normalizeQuery } from '../lib/sql-parser'
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
+/**
+ * Convert MySQL SSL mode to mysql2 client SSL configuration
+ */
+function getSslConfig(sslMode?: MySQLSslMode): string | SslOptions | undefined {
+  switch (sslMode) {
+    case 'disable':
+      return undefined
+    case 'prefer':
+      return { rejectUnauthorized: false }
+    case 'require':
+      return { rejectUnauthorized: false }
+    case 'verify-ca':
+      return { rejectUnauthorized: true, verifyIdentity: false }
+    case 'verify-identity':
+      return { rejectUnauthorized: true, verifyIdentity: true }
+    default:
+      return undefined
+  }
+}
+
 export class MySQLAdapter implements SQLAdapter {
   private pool: Pool | null = null
 
@@ -48,12 +69,15 @@ export class MySQLAdapter implements SQLAdapter {
       return
     }
 
+    const ssl = getSslConfig(this.options.mysqlSslMode)
+
     const pool = mysql.createPool({
       host: this.options.host,
       port: this.options.port,
       database: this.options.database,
       user: this.options.user,
       password: this.options.password,
+      ssl,
       waitForConnections: true,
       connectionLimit: 10,
       queueLimit: 0,

--- a/src/main/utils/validation.ts
+++ b/src/main/utils/validation.ts
@@ -8,7 +8,7 @@ import type {
   TableFilterCondition,
   TableSortRule
 } from '@common/types'
-import type { PostgreSQLSslMode } from '@common/types/sql'
+import type { MySQLSslMode, PostgreSQLSslMode } from '@common/types/sql'
 import { ValidationError } from './errors'
 
 type CreateConnectionInput = {
@@ -122,6 +122,7 @@ const validateSQLConnectionOptions = (options: unknown): SQLConnectionOptions =>
   const password = toNonEmptyString(options.password, 'password')
   const port = toPort(options.port)
   const sslMode = toOptionalSslMode(options.sslMode)
+  const mysqlSslMode = toOptionalMysqlSslMode(options.mysqlSslMode)
 
   return {
     host,
@@ -129,7 +130,8 @@ const validateSQLConnectionOptions = (options: unknown): SQLConnectionOptions =>
     user,
     password,
     port,
-    sslMode
+    sslMode,
+    mysqlSslMode
   }
 }
 
@@ -443,6 +445,25 @@ const toOptionalSslMode = (value: unknown): PostgreSQLSslMode | undefined => {
   }
 
   return value as PostgreSQLSslMode
+}
+
+const toOptionalMysqlSslMode = (value: unknown): MySQLSslMode | undefined => {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+
+  if (typeof value !== 'string') {
+    throw new ValidationError('Invalid value for "mysqlSslMode": expected string or undefined')
+  }
+
+  const validModes: MySQLSslMode[] = ['disable', 'prefer', 'require', 'verify-ca', 'verify-identity']
+  if (!validModes.includes(value as MySQLSslMode)) {
+    throw new ValidationError(
+      `Invalid value for "mysqlSslMode": expected one of ${validModes.join(', ')}`
+    )
+  }
+
+  return value as MySQLSslMode
 }
 
 const toOptionalInteger = (

--- a/src/renderer/src/components/connections/connection-forms/mysql/mysql-connection-form.tsx
+++ b/src/renderer/src/components/connections/connection-forms/mysql/mysql-connection-form.tsx
@@ -1,15 +1,24 @@
 import type { ConnectionProfile, DBConnectionOptions } from '@common/types'
+import type { MySQLSslMode } from '@common/types/sql'
 import { useCreateConnection, useUpdateConnection } from '@renderer/api/queries/connections'
 import { Button } from '@renderer/components/ui/button'
-import { Checkbox } from '@renderer/components/ui/checkbox'
 import { FieldError, FieldGroup, FieldLabel, Field as UIField } from '@renderer/components/ui/field'
 import { Input } from '@renderer/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@renderer/components/ui/select'
 import { Separator } from '@renderer/components/ui/separator'
 import { useForm } from '@tanstack/react-form'
 import { Eye, EyeOff } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import * as z from 'zod'
 import { MySQLQuickConnect } from './mysql-quick-connect'
+
+const SSL_MODE_OPTIONS: MySQLSslMode[] = ['disable', 'prefer', 'require', 'verify-ca', 'verify-identity']
 
 const formSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -18,7 +27,7 @@ const formSchema = z.object({
   database: z.string().min(1, 'Database is required'),
   user: z.string().min(1, 'User is required'),
   password: z.string(),
-  ssl: z.boolean()
+  mysqlSslMode: z.enum(['disable', 'prefer', 'require', 'verify-ca', 'verify-identity'])
 })
 
 type FormValues = z.infer<typeof formSchema>
@@ -32,7 +41,7 @@ function toDefaults(connection?: ConnectionProfile | null): FormValues {
       database: '',
       user: '',
       password: '',
-      ssl: false
+      mysqlSslMode: 'disable'
     }
   }
 
@@ -42,7 +51,7 @@ function toDefaults(connection?: ConnectionProfile | null): FormValues {
     database: string
     user: string
     password: string
-    ssl: boolean
+    mysqlSslMode: MySQLSslMode
   }>
 
   return {
@@ -52,7 +61,7 @@ function toDefaults(connection?: ConnectionProfile | null): FormValues {
     database: opts.database ?? '',
     user: opts.user ?? '',
     password: opts.password ?? '',
-    ssl: Boolean(opts.ssl)
+    mysqlSslMode: opts.mysqlSslMode ?? 'disable'
   }
 }
 
@@ -75,7 +84,7 @@ export function MySQLConnectionForm({ connection, onSuccess }: MySQLConnectionFo
       onSubmit: formSchema
     },
     onSubmit: async ({ value }) => {
-      const { name, host, port, database, user, password, ssl } = value
+      const { name, host, port, database, user, password, mysqlSslMode } = value
 
       let finalPassword = password ?? ''
       if (connection && !finalPassword) {
@@ -89,7 +98,7 @@ export function MySQLConnectionForm({ connection, onSuccess }: MySQLConnectionFo
         database,
         user,
         password: finalPassword,
-        ssl
+        mysqlSslMode
       }
 
       let profile: ConnectionProfile
@@ -119,7 +128,7 @@ export function MySQLConnectionForm({ connection, onSuccess }: MySQLConnectionFo
     database: string
     user: string
     password?: string
-    ssl: boolean
+    mysqlSslMode?: string
   }) => {
     form.setFieldValue('name', values.name)
     form.setFieldValue('host', values.host)
@@ -127,7 +136,7 @@ export function MySQLConnectionForm({ connection, onSuccess }: MySQLConnectionFo
     form.setFieldValue('database', values.database)
     form.setFieldValue('user', values.user)
     form.setFieldValue('password', values.password || '')
-    form.setFieldValue('ssl', values.ssl)
+    form.setFieldValue('mysqlSslMode', (values.mysqlSslMode as MySQLSslMode) || 'disable')
   }
 
   return (
@@ -297,22 +306,31 @@ export function MySQLConnectionForm({ connection, onSuccess }: MySQLConnectionFo
           }}
         </form.Field>
 
-        <form.Field name="ssl">
-          {(field) => (
-            <UIField>
-              <FieldLabel htmlFor={field.name}>SSL</FieldLabel>
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id={field.name}
-                  checked={field.state.value}
-                  onCheckedChange={(v) => field.handleChange(Boolean(v))}
-                />
-                <label htmlFor={field.name} className="text-sm text-muted-foreground select-none">
-                  Enable SSL
-                </label>
-              </div>
-            </UIField>
-          )}
+        <form.Field name="mysqlSslMode">
+          {(field) => {
+            const invalid = field.state.meta.isTouched && !field.state.meta.isValid
+            return (
+              <UIField data-invalid={invalid}>
+                <FieldLabel htmlFor={field.name}>SSL Mode</FieldLabel>
+                <Select
+                  value={field.state.value}
+                  onValueChange={(v) => field.handleChange(v as typeof field.state.value)}
+                >
+                  <SelectTrigger id={field.name}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SSL_MODE_OPTIONS.map((mode) => (
+                      <SelectItem key={mode} value={mode}>
+                        {mode}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {invalid && <FieldError errors={field.state.meta.errors} />}
+              </UIField>
+            )
+          }}
         </form.Field>
       </FieldGroup>
 

--- a/src/renderer/src/components/connections/connection-forms/mysql/mysql-quick-connect.tsx
+++ b/src/renderer/src/components/connections/connection-forms/mysql/mysql-quick-connect.tsx
@@ -11,7 +11,7 @@ interface MySQLQuickConnectProps {
     database: string
     user: string
     password: string
-    ssl: boolean
+    mysqlSslMode?: string
   }) => void
 }
 
@@ -42,11 +42,14 @@ export function MySQLQuickConnect({ onSuccess }: MySQLQuickConnectProps) {
 
       // Parse SSL mode from query parameters
       const sslMode = url.searchParams.get('sslmode') || url.searchParams.get('ssl-mode')
-      const sslEnabled =
-        sslMode === 'require' ||
-        sslMode === 'prefer' ||
-        sslMode === 'verify-full' ||
-        sslMode === 'verify-ca'
+      const mysqlSslMode =
+        sslMode === 'require' || sslMode === 'verify-ca' || sslMode === 'verify-identity'
+          ? sslMode
+          : sslMode === 'prefer' || sslMode === 'preferred'
+            ? 'prefer'
+            : sslMode === 'verify-full' || sslMode === 'verify_identity'
+              ? 'verify-identity'
+              : undefined
 
       onSuccess({
         name,
@@ -55,7 +58,7 @@ export function MySQLQuickConnect({ onSuccess }: MySQLQuickConnectProps) {
         database,
         user: decodeURIComponent(url.username),
         password: decodeURIComponent(url.password),
-        ssl: sslEnabled
+        mysqlSslMode
       })
       setDsn('')
     } catch {


### PR DESCRIPTION
## Summary
Replaces the simple SSL on/off checkbox for MySQL connections with a proper SSL mode selector, matching the granularity already available for PostgreSQL.

## Changes
- New type: MySQLSslMode
- Supported modes: disable, prefer, require, verify-ca, verify-identity
- Added mysqlSslMode optional field to SQLConnectionOptions


## MySQL adapter (mysql.ts)
- Added getSslConfig() that maps each SSL mode to the correct mysql2 SSL options
- prefer / require: connects with SSL but skips certificate validation (rejectUnauthorized: false)
- verify-ca: validates the CA certificate chain, skips hostname check (verifyIdentity: false)
- verify-identity: validates both CA and server hostname (verifyIdentity: true)
- disable / default: no SSL

## Validation (validation.ts)
- Added toOptionalMysqlSslMode validator with enum checking

## UI (mysql-connection-form.tsx, mysql-quick-connect.tsx)
- Replaced the SSL checkbox with a dropdown selector showing all 5 modes
- Quick connect DSN parsing now maps sslmode / ssl-mode query params to the correct MySQLSslModevalue, including aliases (preferred → prefer, verify_identity / verify-full → verify-identity)

## Breaking changes
- Existing saved MySQL connections that used the old ssl: boolean field will lose their SSL setting and default to disable. Users will need to re-select their desired SSL mode.