### PR TITLE
feat: preserve tab scroll on refocus

### DIFF
--- a/apps/desktop/eslint.config.mjs
+++ b/apps/desktop/eslint.config.mjs
@@ -16,6 +16,10 @@ export default defineConfig(
     },
     rules: {
       '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+      ]
     }
   },
   {
@@ -25,7 +29,7 @@ export default defineConfig(
     },
     rules: {
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'off',
+      'react-hooks/exhaustive-deps': 'off'
     }
   },
   {

--- a/apps/desktop/src/renderer/src/features/data-table/components/data-table.tsx
+++ b/apps/desktop/src/renderer/src/features/data-table/components/data-table.tsx
@@ -11,7 +11,9 @@ import {
 import type { QueryResultRow } from '@dbdesk/shared/types'
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@renderer/components/ui/table'
 import { useDataTable } from '@renderer/features/data-table/hooks/use-data-table'
+import { useTabStore } from '@renderer/features/sql-workspace/stores/tab-store'
 import { cn } from '@renderer/shared/lib/utils'
+import { useEffect } from 'react'
 import { ColumnResizer } from './column-resizer'
 import { DataTableCell } from './data-table-cell'
 import { DataTableKeyboardShortcuts } from './data-table-keyboard-shortcuts'
@@ -24,6 +26,7 @@ interface DataTableProps<TData, TValue> {
   rowSelection: RowSelectionState
   onRowSelectionChange: OnChangeFn<RowSelectionState>
   sortRules?: TableSortRule[]
+  tabId?: string
 }
 
 export function DataTable<TData, TValue>({
@@ -33,8 +36,10 @@ export function DataTable<TData, TValue>({
   onTableInteract,
   rowSelection,
   onRowSelectionChange,
-  sortRules
+  sortRules,
+  tabId
 }: DataTableProps<TData, TValue>) {
+  const setTabScrollPosition = useTabStore((s) => s.setTabScrollPosition)
   const {
     table,
     tableContainerRef,
@@ -58,6 +63,45 @@ export function DataTable<TData, TValue>({
   const rowModel = table.getRowModel()
   const rows = rowModel.rows
   const hasRows = rows.length > 0
+
+  useEffect(() => {
+    if (!tabId) {
+      return
+    }
+
+    const container = tableContainerRef.current
+    const savedPosition = useTabStore.getState().tabScrollPositions[tabId]
+    if (!container || !savedPosition) {
+      return
+    }
+
+    container.scrollLeft = savedPosition.left
+    container.scrollTop = savedPosition.top
+  }, [tabId, tableContainerRef, columns.length, data.length])
+
+  useEffect(() => {
+    if (!tabId) {
+      return
+    }
+
+    const container = tableContainerRef.current
+    if (!container) {
+      return
+    }
+
+    const handleScroll = () => {
+      setTabScrollPosition(tabId, {
+        left: container.scrollLeft,
+        top: container.scrollTop
+      })
+    }
+
+    container.addEventListener('scroll', handleScroll, { passive: true })
+
+    return () => {
+      container.removeEventListener('scroll', handleScroll)
+    }
+  }, [tabId, tableContainerRef, setTabScrollPosition])
 
   return (
     <>

--- a/apps/desktop/src/renderer/src/features/data-table/components/index.tsx
+++ b/apps/desktop/src/renderer/src/features/data-table/components/index.tsx
@@ -69,6 +69,7 @@ export const SqlTable = ({
           rowSelection={rowSelection}
           onRowSelectionChange={onRowSelectionChange}
           sortRules={sortRules}
+          tabId={tabId}
         />
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/features/sql-workspace/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/features/sql-workspace/stores/tab-store.ts
@@ -38,16 +38,22 @@ export interface QueryTab extends BaseTab {
 }
 
 export type Tab = TableTab | QueryTab
+type TabScrollPosition = {
+  left: number
+  top: number
+}
 
 interface TabStore {
   tabs: Tab[]
   activeTabId: string | null
+  tabScrollPositions: Record<string, TabScrollPosition>
 
   // Common actions
   removeTab: (tabId: string) => void
   setActiveTab: (tabId: string) => void
   reset: () => void
   moveTab: (fromIndex: number, toIndex: number) => void
+  setTabScrollPosition: (tabId: string, position: TabScrollPosition) => void
 
   // Table-specific actions
   addTableTab: (schema: string, table: string) => string
@@ -94,6 +100,7 @@ const createDefaultQueryTab = (): QueryTab => ({
 export const useTabStore = create<TabStore>((set, get) => ({
   tabs: [],
   activeTabId: null,
+  tabScrollPositions: {},
 
   // Common actions
   removeTab: (tabId: string) => {
@@ -111,7 +118,13 @@ export const useTabStore = create<TabStore>((set, get) => ({
         }
       }
 
-      return { tabs: newTabs, activeTabId: newActiveTabId }
+      const { [tabId]: _removedPosition, ...remainingPositions } = state.tabScrollPositions
+
+      return {
+        tabs: newTabs,
+        activeTabId: newActiveTabId,
+        tabScrollPositions: remainingPositions
+      }
     })
   },
 
@@ -123,7 +136,7 @@ export const useTabStore = create<TabStore>((set, get) => ({
   },
 
   reset: () => {
-    set({ tabs: [], activeTabId: null })
+    set({ tabs: [], activeTabId: null, tabScrollPositions: {} })
   },
 
   moveTab: (fromIndex: number, toIndex: number) => {
@@ -133,6 +146,15 @@ export const useTabStore = create<TabStore>((set, get) => ({
       newTabs.splice(toIndex, 0, movedTab)
       return { tabs: newTabs }
     })
+  },
+
+  setTabScrollPosition: (tabId: string, position: TabScrollPosition) => {
+    set((state) => ({
+      tabScrollPositions: {
+        ...state.tabScrollPositions,
+        [tabId]: position
+      }
+    }))
   },
 
   // Table-specific actions
@@ -248,7 +270,7 @@ export const useTabStore = create<TabStore>((set, get) => ({
       }
     })
 
-    set({ tabs, activeTabId })
+    set({ tabs, activeTabId, tabScrollPositions: {} })
   },
 
   serializeState: () => {

--- a/apps/desktop/src/renderer/src/features/sql-workspace/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/features/sql-workspace/stores/tab-store.ts
@@ -118,7 +118,7 @@ export const useTabStore = create<TabStore>((set, get) => ({
         }
       }
 
-      const { [tabId]: _removedPosition, ...remainingPositions } = state.tabScrollPositions
+      const { [tabId]: _, ...remainingPositions } = state.tabScrollPositions
 
       return {
         tabs: newTabs,


### PR DESCRIPTION
This pull request adds support for remembering and restoring the scroll position of data tables on a per-tab basis in the SQL workspace. This ensures that when users switch between tabs or return to a tab, the table view remains at the same scroll position as when they left it, improving the user experience for navigating large datasets.

Tab scroll position persistence:

* Added a `tabScrollPositions` state and related actions (`setTabScrollPosition`) to the `useTabStore` store to track and update the scroll position for each tab. The scroll positions are reset when tabs are removed, the tab store is reset, or when all tabs are closed. [[1]](diffhunk://#diff-3f213b08b8dc44100a3f535ddf95ee9ea47bf7584d4586407de7489bbfb92bc0R41-R56) [[2]](diffhunk://#diff-3f213b08b8dc44100a3f535ddf95ee9ea47bf7584d4586407de7489bbfb92bc0R103) [[3]](diffhunk://#diff-3f213b08b8dc44100a3f535ddf95ee9ea47bf7584d4586407de7489bbfb92bc0L114-R127) [[4]](diffhunk://#diff-3f213b08b8dc44100a3f535ddf95ee9ea47bf7584d4586407de7489bbfb92bc0L126-R139) [[5]](diffhunk://#diff-3f213b08b8dc44100a3f535ddf95ee9ea47bf7584d4586407de7489bbfb92bc0R151-R159) [[6]](diffhunk://#diff-3f213b08b8dc44100a3f535ddf95ee9ea47bf7584d4586407de7489bbfb92bc0L251-R273)
* Updated the `DataTable` component to accept an optional `tabId` prop. When provided, the component restores the scroll position from the store on mount and saves the scroll position on scroll events. [[1]](diffhunk://#diff-f504db04e9bfb48c9ee16026f54506d4f2d8d4460b2a694f3323fad6954c7cd5R29) [[2]](diffhunk://#diff-f504db04e9bfb48c9ee16026f54506d4f2d8d4460b2a694f3323fad6954c7cd5L36-R42) [[3]](diffhunk://#diff-f504db04e9bfb48c9ee16026f54506d4f2d8d4460b2a694f3323fad6954c7cd5R67-R105)
* Passed the `tabId` prop from the `SqlTable` component to the `DataTable` component to enable per-tab scroll position handling.
* Imported necessary hooks and utilities (`useTabStore`, `useEffect`) into `data-table.tsx` to support the new scroll position logic.