### PR TITLE
feat: persistent session cache and 1-year session TTL

### DIFF
--- a/apps/desktop/src/main/ipc/auth-handlers.ts
+++ b/apps/desktop/src/main/ipc/auth-handlers.ts
@@ -3,7 +3,8 @@ import { authManager } from '../lib/auth-manager'
 
 export function registerAuthHandlers() {
   typedHandle('auth:get-session', async () => {
-    const session = await authManager.getSession()
+    // Returns cached session immediately (no network)
+    const session = authManager.getSession()
     console.log('[ipc] auth:get-session →', session ? `user=${session.user?.email}` : 'null')
     return session
   })

--- a/apps/desktop/src/main/lib/auth-manager.ts
+++ b/apps/desktop/src/main/lib/auth-manager.ts
@@ -1,12 +1,13 @@
 import type { BrowserWindow } from 'electron'
 import { betterAuthClient } from './better-auth-client'
+import { getCachedSession, setCachedSession, clearCachedSession } from './session-cache'
 
 interface SessionResponse {
   session: { id: string; expiresAt: string; token: string; userId: string }
   user: { id: string; name: string; email: string; image: string | null }
 }
 
-let sessionPromise: Promise<SessionResponse | null> | null = null
+let _getWindow: (() => BrowserWindow | null) | null = null
 
 function unwrapData<T>(value: unknown): T | null {
   if (!value || typeof value !== 'object') return null
@@ -18,8 +19,30 @@ function unwrapData<T>(value: unknown): T | null {
   return value as T
 }
 
+/**
+ * Notify the renderer that the session was invalidated
+ * (server returned null / session expired).
+ */
+function notifySessionInvalidated(): void {
+  const win = _getWindow?.()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('auth:session-invalidated')
+  }
+}
+
+/**
+ * Notify the renderer that the session was verified and refreshed.
+ */
+function notifySessionRefreshed(session: SessionResponse): void {
+  const win = _getWindow?.()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('auth:session-refreshed', session)
+  }
+}
+
 export const authManager = {
   setup(getWindow?: () => BrowserWindow | null) {
+    _getWindow = getWindow ?? null
     console.log('[auth-manager] setup called')
     try {
       betterAuthClient.setupMain({
@@ -38,30 +61,94 @@ export const authManager = {
     await betterAuthClient.requestAuth()
   },
 
-  async getSession(): Promise<SessionResponse | null> {
-    if (sessionPromise) return sessionPromise
-
-    sessionPromise = this._fetchSession().finally(() => {
-      sessionPromise = null
-    })
-
-    return sessionPromise
+  /**
+   * Fast session fetch — returns cached session from local SQLite immediately.
+   * Triggers a background server verification that updates the cache.
+   * Use this for startup — the user sees the UI instantly.
+   */
+  getSession(): SessionResponse | null {
+    const cached = getCachedSession()
+    if (cached) {
+      // Fire background verification
+      void this.verifySessionInBackground()
+      return {
+        session: {
+          id: cached.id,
+          expiresAt: new Date(cached.sessionExpiresAt).toISOString(),
+          token: cached.sessionToken,
+          userId: cached.userId
+        },
+        user: {
+          id: cached.userId,
+          name: cached.userName,
+          email: cached.userEmail,
+          image: cached.userImage
+        }
+      }
+    }
+    return null
   },
 
-  async _fetchSession(): Promise<SessionResponse | null> {
+  /**
+   * Force a fresh session fetch from the server.
+   * Updates the local cache if successful, clears it if not.
+   * Returns the session or null.
+   */
+  async getSessionFresh(): Promise<SessionResponse | null> {
     try {
       const session = await betterAuthClient.getSession()
       const result = unwrapData<SessionResponse>(session)
-      console.log('[auth-manager] _fetchSession result:', result ? `user=${result.user?.email}` : 'null')
+      if (result?.user) {
+        // Update local cache
+        setCachedSession({
+          id: result.session.id,
+          userId: result.user.id,
+          userName: result.user.name,
+          userEmail: result.user.email,
+          userImage: result.user.image,
+          sessionToken: result.session.token,
+          sessionExpiresAt: new Date(result.session.expiresAt).getTime()
+        })
+        console.log('[auth-manager] getSessionFresh: success', result.user.email)
+      } else {
+        clearCachedSession()
+        console.log('[auth-manager] getSessionFresh: null session')
+      }
       return result
     } catch (err) {
-      console.error('[auth-manager] _fetchSession error:', err)
+      console.error('[auth-manager] getSessionFresh error:', err)
+      // Don't clear cache on network error — the session might still be valid
       return null
     }
   },
 
+  /**
+   * Verify the session against the server in the background.
+   * Updates/clears the local cache and notifies the renderer of any changes.
+   */
+  async verifySessionInBackground(): Promise<void> {
+    const result = await this.getSessionFresh()
+    if (result) {
+      notifySessionRefreshed(result)
+    } else {
+      // Only clear + notify if we previously had a cached session
+      // (avoid spurious events if user is already logged out)
+      const hadCache = getCachedSession() !== null
+      if (hadCache) {
+        clearCachedSession()
+        notifySessionInvalidated()
+      }
+    }
+  },
+
   async getToken(): Promise<string | null> {
-    const session = await this.getSession()
+    // Try cache first
+    const cached = getCachedSession()
+    if (cached) {
+      return cached.sessionToken
+    }
+    // Fallback to server
+    const session = await this.getSessionFresh()
     return session?.session.token ?? null
   },
 
@@ -69,7 +156,7 @@ export const authManager = {
     try {
       await betterAuthClient.signOut()
     } finally {
-      sessionPromise = null
+      clearCachedSession()
     }
   },
 }

--- a/apps/desktop/src/main/lib/session-cache.ts
+++ b/apps/desktop/src/main/lib/session-cache.ts
@@ -1,0 +1,92 @@
+import { getSqlite } from '@dbdesk/db'
+
+const CACHE_KEY = 'current'
+
+interface CachedSession {
+  id: string
+  userId: string
+  userName: string
+  userEmail: string
+  userImage: string | null
+  sessionToken: string
+  sessionExpiresAt: number
+}
+
+interface CachedSessionRow {
+  id: string
+  user_id: string
+  user_name: string
+  user_email: string
+  user_image: string | null
+  session_token: string
+  session_expires_at: number
+  cached_at: number
+}
+
+/**
+ * Read the cached session from local SQLite.
+ * Returns null if no cache exists or the server-side expiry has passed.
+ */
+export function getCachedSession(): CachedSession | null {
+  try {
+    const row = getSqlite()
+      .prepare('SELECT * FROM auth_session_cache WHERE id = ?')
+      .get(CACHE_KEY) as CachedSessionRow | undefined
+
+    if (!row) return null
+
+    // If the server-side expiry has passed, treat cache as stale
+    if (row.session_expires_at < Date.now()) {
+      clearCachedSession()
+      return null
+    }
+
+    return {
+      id: row.id,
+      userId: row.user_id,
+      userName: row.user_name,
+      userEmail: row.user_email,
+      userImage: row.user_image,
+      sessionToken: row.session_token,
+      sessionExpiresAt: row.session_expires_at
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Persist a session to the local SQLite cache.
+ */
+export function setCachedSession(session: CachedSession): void {
+  try {
+    getSqlite()
+      .prepare(
+        `INSERT OR REPLACE INTO auth_session_cache (id, user_id, user_name, user_email, user_image, session_token, session_expires_at, cached_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        CACHE_KEY,
+        session.userId,
+        session.userName,
+        session.userEmail,
+        session.userImage ?? null,
+        session.sessionToken,
+        session.sessionExpiresAt,
+        Date.now()
+      )
+  } catch (err) {
+    console.error('[session-cache] setCachedSession error:', err)
+  }
+}
+
+/**
+ * Delete the cached session from local SQLite.
+ */
+export function clearCachedSession(): void {
+  try {
+    getSqlite().prepare('DELETE FROM auth_session_cache WHERE id = ?').run(CACHE_KEY)
+  } catch (err) {
+    console.error('[session-cache] clearCachedSession error:', err)
+  }
+}

--- a/apps/desktop/src/preload/dbdesk-api.ts
+++ b/apps/desktop/src/preload/dbdesk-api.ts
@@ -6,7 +6,7 @@ import type {
   DBConnectionOptions,
   ExportTableOptions,
   QueryResultRow,
-  TableDataOptions,
+  TableDataOptions
 } from '@dbdesk/shared/types'
 import { ipcRenderer } from 'electron'
 import { typedInvoke } from './typed-ipc'
@@ -17,53 +17,48 @@ export const dbdeskAPI = {
 
   // ── Connections CRUD ──
   listConnections: () => typedInvoke('connections:list'),
-  getConnection: (connectionId: string) =>
-    typedInvoke('connections:get', { connectionId }),
+  getConnection: (connectionId: string) => typedInvoke('connections:get', { connectionId }),
   createConnection: (name: string, type: DatabaseType, options: DBConnectionOptions) =>
     typedInvoke('connections:create', { name, type, options }),
   updateConnection: (
     connectionId: string,
     name: string,
     type: DatabaseType,
-    options: DBConnectionOptions,
+    options: DBConnectionOptions
   ) => typedInvoke('connections:update', { connectionId, name, type, options }),
-  connect: (connectionId: string) =>
-    typedInvoke('connections:connect', { connectionId }),
-  disconnect: (connectionId: string) =>
-    typedInvoke('connections:disconnect', { connectionId }),
-  deleteConnection: (connectionId: string) =>
-    typedInvoke('connections:delete', { connectionId }),
+  connect: (connectionId: string) => typedInvoke('connections:connect', { connectionId }),
+  disconnect: (connectionId: string) => typedInvoke('connections:disconnect', { connectionId }),
+  deleteConnection: (connectionId: string) => typedInvoke('connections:delete', { connectionId }),
 
   // ── Query ──
   runQuery: (
     connectionId: string,
     query: string,
-    options?: { limit?: number; offset?: number; queryId?: string },
+    options?: { limit?: number; offset?: number; queryId?: string }
   ) =>
     typedInvoke('query:run', {
       connectionId,
       query,
       limit: options?.limit,
       offset: options?.offset,
-      queryId: options?.queryId,
+      queryId: options?.queryId
     }),
   runManyQueries: (
     connectionId: string,
     queries: string[],
-    options?: { limit?: number; offset?: number },
+    options?: { limit?: number; offset?: number }
   ) =>
     typedInvoke('query:runMany', {
       connectionId,
       queries,
       limit: options?.limit,
-      offset: options?.offset,
+      offset: options?.offset
     }),
   cancelQuery: (connectionId: string, queryId: string) =>
     typedInvoke('query:cancel', { connectionId, queryId }),
 
   // ── Schema ──
-  listSchemas: (connectionId: string) =>
-    typedInvoke('schema:list', { connectionId }),
+  listSchemas: (connectionId: string) => typedInvoke('schema:list', { connectionId }),
   listTables: (connectionId: string, schema: string) =>
     typedInvoke('schema:tables', { connectionId, schema }),
   listSchemasWithTables: (connectionId: string) =>
@@ -76,43 +71,44 @@ export const dbdeskAPI = {
     connectionId: string,
     schema: string,
     table: string,
-    options: Pick<TableDataOptions, 'limit' | 'offset' | 'sortRules' | 'filters'> = {},
+    options: Pick<TableDataOptions, 'limit' | 'offset' | 'sortRules' | 'filters'> = {}
   ) =>
     typedInvoke('table:data', {
       connectionId,
       schema,
       table,
-      ...options,
+      ...options
     }),
-  deleteTableRows: (
-    connectionId: string,
-    schema: string,
-    table: string,
-    rows: QueryResultRow[],
-  ) => typedInvoke('table:deleteRows', { connectionId, schema, table, rows }),
+  deleteTableRows: (connectionId: string, schema: string, table: string, rows: QueryResultRow[]) =>
+    typedInvoke('table:deleteRows', { connectionId, schema, table, rows }),
   updateTableCell: (
     connectionId: string,
     schema: string,
     table: string,
     columnToUpdate: string,
     newValue: unknown,
-    row: QueryResultRow,
-  ) => typedInvoke('table:updateCell', { connectionId, schema, table, columnToUpdate, newValue, row }),
-  insertTableRow: (connectionId: string, schema: string, table: string, values: Record<string, unknown>) =>
-    typedInvoke('table:insertRow', { connectionId, schema, table, values }),
+    row: QueryResultRow
+  ) =>
+    typedInvoke('table:updateCell', { connectionId, schema, table, columnToUpdate, newValue, row }),
+  insertTableRow: (
+    connectionId: string,
+    schema: string,
+    table: string,
+    values: Record<string, unknown>
+  ) => typedInvoke('table:insertRow', { connectionId, schema, table, values }),
 
   // ── Table Export / DDL ──
   exportTableAsCSV: (
     connectionId: string,
     schema: string,
     table: string,
-    options: Pick<ExportTableOptions, 'sortRules' | 'filters'> = {},
+    options: Pick<ExportTableOptions, 'sortRules' | 'filters'> = {}
   ) => typedInvoke('table:exportCSV', { connectionId, schema, table, ...options }),
   exportTableAsSQL: (
     connectionId: string,
     schema: string,
     table: string,
-    options: Pick<ExportTableOptions, 'sortRules' | 'filters'> = {},
+    options: Pick<ExportTableOptions, 'sortRules' | 'filters'> = {}
   ) => typedInvoke('table:exportSQL', { connectionId, schema, table, ...options }),
   deleteTable: (connectionId: string, schema: string, table: string) =>
     typedInvoke('table:delete', { connectionId, schema, table }),
@@ -120,16 +116,12 @@ export const dbdeskAPI = {
     typedInvoke('table:create', { connectionId, schema, table, columns }),
 
   // ── Workspace ──
-  loadWorkspace: (connectionId: string) =>
-    typedInvoke('workspace:load', { connectionId }),
-  saveWorkspace: (workspace: ConnectionWorkspace) =>
-    typedInvoke('workspace:save', { workspace }),
-  deleteWorkspace: (connectionId: string) =>
-    typedInvoke('workspace:delete', { connectionId }),
+  loadWorkspace: (connectionId: string) => typedInvoke('workspace:load', { connectionId }),
+  saveWorkspace: (workspace: ConnectionWorkspace) => typedInvoke('workspace:save', { workspace }),
+  deleteWorkspace: (connectionId: string) => typedInvoke('workspace:delete', { connectionId }),
 
   // ── Saved Queries ──
-  loadQueries: (connectionId: string) =>
-    typedInvoke('queries:load', { connectionId }),
+  loadQueries: (connectionId: string) => typedInvoke('queries:load', { connectionId }),
   saveQuery: (connectionId: string, id: string, name: string, content: string) =>
     typedInvoke('queries:save', { connectionId, id, name, content }),
   deleteQuery: (connectionId: string, queryId: string) =>
@@ -138,18 +130,15 @@ export const dbdeskAPI = {
     typedInvoke('queries:update', { connectionId, queryId, name, content }),
 
   // ── Dashboards ──
-  loadDashboards: (connectionId: string) =>
-    typedInvoke('dashboards:load', { connectionId }),
+  loadDashboards: (connectionId: string) => typedInvoke('dashboards:load', { connectionId }),
   getDashboard: (connectionId: string, dashboardId: string) =>
     typedInvoke('dashboards:get', { connectionId, dashboardId }),
   saveDashboard: (dashboard: DashboardConfig) => typedInvoke('dashboards:save', dashboard),
   deleteDashboard: (connectionId: string, dashboardId: string) =>
     typedInvoke('dashboards:delete', { connectionId, dashboardId }),
-  persistDashboard: (dashboardId: string) =>
-    typedInvoke('dashboards:persist', { dashboardId }),
+  persistDashboard: (dashboardId: string) => typedInvoke('dashboards:persist', { dashboardId }),
   persistAllDashboards: () => typedInvoke('dashboards:persist-all'),
-  exportDashboards: (connectionId?: string) =>
-    typedInvoke('dashboards:export', { connectionId }),
+  exportDashboards: (connectionId?: string) => typedInvoke('dashboards:export', { connectionId }),
   importDashboards: (dashboards: DashboardConfig[], overwrite?: boolean) =>
     typedInvoke('dashboards:import', { dashboards, overwrite }),
 
@@ -158,14 +147,41 @@ export const dbdeskAPI = {
   getToken: () => typedInvoke('auth:get-token'),
   logout: () => typedInvoke('auth:logout'),
 
+  onSessionInvalidated(callback: () => void): () => void {
+    const handler = () => callback()
+    ipcRenderer.on('auth:session-invalidated', handler)
+    return () => ipcRenderer.removeListener('auth:session-invalidated', handler)
+  },
+  onSessionRefreshed(
+    callback: (session: {
+      session: { id: string; expiresAt: string; token: string; userId: string }
+      user: { id: string; name: string; email: string; image: string | null }
+    }) => void
+  ): () => void {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      session: {
+        session: { id: string; expiresAt: string; token: string; userId: string }
+        user: { id: string; name: string; email: string; image: string | null }
+      }
+    ) => callback(session)
+    ipcRenderer.on('auth:session-refreshed', handler)
+    return () => ipcRenderer.removeListener('auth:session-refreshed', handler)
+  },
+
   // ── Updates ──
   checkForUpdate: () => typedInvoke('update:check'),
   downloadUpdate: () => typedInvoke('update:download'),
   installUpdate: () => typedInvoke('update:install'),
   getAppVersion: () => typedInvoke('update:get-version'),
 
-  onUpdateAvailable(callback: (data: { version: string; releaseNotes?: string }) => void): () => void {
-    const handler = (_event: Electron.IpcRendererEvent, data: { version: string; releaseNotes?: string }) => callback(data)
+  onUpdateAvailable(
+    callback: (data: { version: string; releaseNotes?: string }) => void
+  ): () => void {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: { version: string; releaseNotes?: string }
+    ) => callback(data)
     ipcRenderer.on('update:available', handler)
     return () => ipcRenderer.removeListener('update:available', handler)
   },
@@ -190,7 +206,7 @@ export const dbdeskAPI = {
   maximizeWindow: () => ipcRenderer.invoke('window:maximize') as Promise<void>,
   closeWindow: () => ipcRenderer.invoke('window:close') as Promise<void>,
   moveWindow: (deltaX: number, deltaY: number) =>
-    ipcRenderer.invoke('window:move', { deltaX, deltaY }) as Promise<void>,
+    ipcRenderer.invoke('window:move', { deltaX, deltaY }) as Promise<void>
 }
 
 export type DbdeskAPI = typeof dbdeskAPI

--- a/apps/desktop/src/renderer/src/features/auth/components/auth-overlay.tsx
+++ b/apps/desktop/src/renderer/src/features/auth/components/auth-overlay.tsx
@@ -1,0 +1,44 @@
+import { useAuthStore } from '@renderer/features/auth/stores/auth-store'
+import { requestSignIn } from '@renderer/features/auth/lib/auth-utils'
+import { Button } from '@renderer/components/ui/button'
+import DbDeskLogo from '@renderer/assets/dbdesk-logo.svg'
+
+/**
+ * Full-screen overlay shown when the background session verification
+ * finds the session expired.  The user's page stays visible underneath
+ * so they don't lose context.
+ */
+export function AuthOverlay() {
+  const sessionExpired = useAuthStore((s) => s.sessionExpired)
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+
+  if (!sessionExpired || isAuthenticated) return null
+
+  const handleLogin = async () => {
+    try {
+      await requestSignIn()
+    } catch (error) {
+      console.error('[auth-overlay] Failed to initiate login:', error)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-full max-w-md space-y-8 rounded-lg p-8 flex flex-col bg-background shadow-2xl">
+        <div className="flex flex-col gap-2">
+          <img src={DbDeskLogo} alt="DBDesk" className="h-8 w-8" />
+          <h1 className="text-2xl flex items-center font-bold">Session expired</h1>
+          <p className="text-sm text-muted-foreground">
+            Your session has expired. Please sign in again to continue.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <Button onClick={handleLogin} variant="default" className="w-full" size="sm">
+            Sign in
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/features/auth/stores/auth-store.ts
+++ b/apps/desktop/src/renderer/src/features/auth/stores/auth-store.ts
@@ -13,15 +13,19 @@ export interface AuthState {
   token: string | null
   isLoading: boolean
   isAuthenticated: boolean
+  /** Set to true when the background session verification finds the session expired.
+   *  The user stays on the current page but sees a sign-in overlay. */
+  sessionExpired: boolean
 
   setUser: (user: AuthUser | null) => void
   setToken: (token: string | null) => void
   setIsLoading: (loading: boolean) => void
+  setSessionExpired: (expired: boolean) => void
   logout: () => void
 
   /**
    * Fetch session + token from the main process and update the store.
-   * Called on startup and whenever the main process signals a change.
+   * Returns instantly from the local cache — no network call on startup.
    */
   refreshSession: () => Promise<void>
 }
@@ -31,6 +35,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   token: null,
   isLoading: true,
   isAuthenticated: false,
+  sessionExpired: false,
 
   setUser: (user) =>
     set({
@@ -45,11 +50,14 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   setIsLoading: (isLoading) => set({ isLoading }),
 
+  setSessionExpired: (sessionExpired) => set({ sessionExpired }),
+
   logout: () =>
     set({
       user: null,
       token: null,
-      isAuthenticated: false
+      isAuthenticated: false,
+      sessionExpired: false
     }),
 
   refreshSession: async () => {
@@ -64,20 +72,20 @@ export const useAuthStore = create<AuthState>((set) => ({
           user: session.user,
           token: tokenResult.token,
           isAuthenticated: true,
-          isLoading: false
+          isLoading: false,
+          sessionExpired: false
         })
       } else {
-        // Only clear auth state if we weren't already authenticated.
-        // After deep-link auth the token store write may still be in-flight,
-        // so getSession() can transiently return null. Preserve the user that
-        // was set directly by onAuthenticated; only logout() should clear it.
+        // No cached session — this is the first-time / logged-out flow.
+        // Don't clear auth state if already authenticated (deep-link race).
         const current = useAuthStore.getState()
         if (!current.isAuthenticated) {
           set({
             user: null,
             token: null,
             isAuthenticated: false,
-            isLoading: false
+            isLoading: false,
+            sessionExpired: false
           })
         } else {
           set({ isLoading: false })

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -12,7 +12,6 @@ import { useAuthStore } from '@renderer/features/auth/stores/auth-store'
 import { queryClient } from '@renderer/shared/lib/query-client'
 import { registerWorkspaceFlushListener } from '@renderer/features/sql-workspace/lib/workspace'
 import { routeTree } from './routeTree.gen'
-import DbDeskLogo from '@renderer/assets/dbdesk-logo.svg'
 
 import '@renderer/features/editor/monaco/workers'
 
@@ -93,33 +92,31 @@ declare module '@tanstack/react-router' {
   }
 }
 
-// Pre-load auth state before rendering to avoid async beforeLoad pending issues
+// Listen for background session invalidation from the main process.
+// When the server verification finds the session expired, we show a
+// sign-in overlay instead of redirecting — the user keeps their page visible.
+window.dbdesk.onSessionInvalidated(() => {
+  console.log('[auth] session invalidated by server background check')
+  useAuthStore.getState().setSessionExpired(true)
+})
+
+// Listen for background session refresh from the main process.
+// When the server confirms the session is valid, update the store.
+window.dbdesk.onSessionRefreshed((session) => {
+  console.log('[auth] session refreshed by server background check')
+  useAuthStore.getState().setUser(session.user)
+  if (session.session?.token) {
+    useAuthStore.getState().setToken(session.session.token)
+  }
+  useAuthStore.getState().setSessionExpired(false)
+})
+
+// Refresh session from local cache (instant — no network) then render.
+// The cache is checked first, so beforeLoad in the router is synchronous.
 async function init() {
-  const rootElement = document.getElementById('root')!
-
-  // Show splash screen while checking auth
-  rootElement.innerHTML = `
-    <div id="splash" style="
-      height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: oklch(0.185 0 0);
-    ">
-      <img src="${DbDeskLogo}" alt="DBDesk" style="width: 48px; height: 48px; animation: splash-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;" />
-    </div>
-    <style>
-      @keyframes splash-pulse {
-        0%, 100% { opacity: 1; }
-        50% { opacity: .5; }
-      }
-    </style>
-  `
-
-  // Refresh session once before rendering so beforeLoad can be synchronous
   await useAuthStore.getState().refreshSession()
 
-  const root = ReactDOM.createRoot(rootElement)
+  const root = ReactDOM.createRoot(document.getElementById('root')!)
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>

--- a/apps/desktop/src/renderer/src/routes/__root.tsx
+++ b/apps/desktop/src/renderer/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { Titlebar } from '@renderer/components/shell/titlebar'
 import { Toaster } from '@renderer/components/ui/sonner'
 import { useAuthStore } from '@renderer/features/auth/stores/auth-store'
 import { MainSidebar } from '@renderer/components/shell/main-sidebar'
+import { AuthOverlay } from '@renderer/features/auth/components/auth-overlay'
 import { useUpdateToast } from '@renderer/shared/hooks/use-update-toast'
 import { redirect } from '@tanstack/react-router'
 
@@ -22,6 +23,7 @@ const RootLayout = () => {
           </main>
         </div>
       </div>
+      <AuthOverlay />
       <Toaster position="top-right" />
     </>
   )
@@ -31,11 +33,13 @@ const NotFound = () => <Navigate to="/" replace />
 
 export const Route = createRootRoute({
   beforeLoad: ({ location }) => {
-    const { isAuthenticated } = useAuthStore.getState()
+    const { isAuthenticated, sessionExpired } = useAuthStore.getState()
     const pathname = location.pathname ?? '/'
     const isAuthRoute = pathname === '/auth'
 
-    if (!isAuthenticated && !isAuthRoute) {
+    // If the session expired in the background, don't redirect —
+    // keep the user on the current page with the sign-in overlay.
+    if (!isAuthenticated && !isAuthRoute && !sessionExpired) {
       throw redirect({ to: '/auth' })
     }
 

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -13,6 +13,10 @@ export const auth = betterAuth({
     schema,
   }),
   plugins: [bearer(), electron()],
+  session: {
+    expiresIn: 60 * 60 * 24 * 365, // 1 year
+    updateAge: 60 * 60 * 24 * 30,  // refresh after 30 days of inactivity
+  },
   emailAndPassword: {
     enabled: true,
   },

--- a/packages/db/drizzle/0002_lonely_fat_cobra.sql
+++ b/packages/db/drizzle/0002_lonely_fat_cobra.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `auth_session_cache` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`user_name` text NOT NULL,
+	`user_email` text NOT NULL,
+	`user_image` text,
+	`session_token` text NOT NULL,
+	`session_expires_at` integer NOT NULL,
+	`cached_at` integer NOT NULL
+);

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,366 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b773532e-ccf6-4ea1-89a1-b294fecff2dc",
+  "prevId": "926e6976-858a-4fce-9363-f5ea7dc2fe62",
+  "tables": {
+    "app_meta": {
+      "name": "app_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_kv": {
+      "name": "auth_kv",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_session_cache": {
+      "name": "auth_session_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_image": {
+          "name": "user_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_expires_at": {
+          "name": "session_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection_profiles": {
+      "name": "connection_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "options_json": {
+          "name": "options_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tabs_json": {
+          "name": "tabs_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_tab_id": {
+          "name": "active_tab_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dashboards": {
+      "name": "dashboards",
+      "columns": {
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "layout_json": {
+          "name": "layout_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "widgets_json": {
+          "name": "widgets_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dashboards_connection_id_connection_profiles_id_fk": {
+          "name": "dashboards_connection_id_connection_profiles_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "connection_profiles",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_queries": {
+      "name": "saved_queries",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_queries_connection_id_connection_profiles_id_fk": {
+          "name": "saved_queries_connection_id_connection_profiles_id_fk",
+          "tableFrom": "saved_queries",
+          "tableTo": "connection_profiles",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_queries_connection_id_id_pk": {
+          "columns": [
+            "connection_id",
+            "id"
+          ],
+          "name": "saved_queries_connection_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779341747945,
       "tag": "0001_swift_cobalt_man",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1781972274141,
+      "tag": "0002_lonely_fat_cobra",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -38,6 +38,17 @@ export const appMeta = sqliteTable('app_meta', {
   value: text('value').notNull()
 })
 
+export const authSessionCache = sqliteTable('auth_session_cache', {
+  id: text('id').primaryKey(),
+  userId: text('user_id').notNull(),
+  userName: text('user_name').notNull(),
+  userEmail: text('user_email').notNull(),
+  userImage: text('user_image'),
+  sessionToken: text('session_token').notNull(),
+  sessionExpiresAt: integer('session_expires_at').notNull(),
+  cachedAt: integer('cached_at').notNull()
+})
+
 export const dashboards = sqliteTable('dashboards', {
   dashboardId: text('dashboard_id').primaryKey(),
   connectionId: text('connection_id')


### PR DESCRIPTION
## Summary

Replaces the network-blocking startup session check with a local SQLite cache. The app now shows UI instantly on startup and verifies the session against the server in the background.

## Changes

- **Server** (`apps/server/src/auth.ts`): Set Better Auth `session.expiresIn` to 1 year with `updateAge` of 30 days
- **DB** (`packages/db/`): Added `auth_session_cache` table + Drizzle migration 0002
- **Session cache** (`apps/desktop/src/main/lib/session-cache.ts`): Sync SQLite-backed cache (get/set/clear)
- **Auth manager** (`apps/desktop/src/main/lib/auth-manager.ts`): Two-phase fetch — return cached session instantly, verify against server in background, send `auth:session-invalidated` / `auth:session-refreshed` events to renderer
- **IPC**: Added `onSessionInvalidated` and `onSessionRefreshed` preload listeners
- **Renderer** (`apps/desktop/src/renderer/src/main.tsx`): Removed splash screen, startup is instant; registers background auth event listeners
- **Auth store**: Added `sessionExpired` flag
- **Auth overlay** (`apps/desktop/src/renderer/src/features/auth/components/auth-overlay.tsx`): Sign-in overlay with backdrop blur, shown when session expires mid-session (no hard redirect)
- **Route guards**: Skip redirect when `sessionExpired` is true

## UX Flow

- **Has cached session**: App opens instantly → main UI visible immediately → background verifies with server → cache refreshed or session-invalidated overlay shown
- **No cached session**: App opens → auth page rendered immediately (no blank flash)
- **Session expires mid-session**: Sign-in overlay appears on top of current page — user's local data stays visible